### PR TITLE
refs #8874 - rework POT/PO updates for gettext 3's edit.po

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,6 @@ test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
 locale/*.mo
+locale/*/*.edit.po
+locale/*/*.po.time_stamp
 locale/*/*.pox

--- a/.tx/config
+++ b/.tx/config
@@ -2,7 +2,7 @@
 host = https://www.transifex.com
 
 [foreman.foreman_plugin_template]
-file_filter = locale/<lang>/foreman_plugin_template.po
+file_filter = locale/<lang>/foreman_plugin_template.edit.po
 source_file = locale/foreman_plugin_template.pot
 source_lang = en
 type = PO

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -10,9 +10,10 @@ DOMAIN = foreman_plugin_template
 VERSION = $(shell ruby -e 'require "rubygems";spec = Gem::Specification::load(Dir.glob("../*.gemspec")[0]);puts spec.version')
 POTFILE = $(DOMAIN).pot
 MOFILE = $(DOMAIN).mo
-POFILES = $(shell find . -name '*.po')
+POFILES = $(shell find . -name '$(DOMAIN).po')
 MOFILES = $(patsubst %.po,%.mo,$(POFILES))
 POXFILES = $(patsubst %.po,%.pox,$(POFILES))
+EDITFILES = $(patsubst %.po,%.edit.po,$(POFILES))
 
 %.mo: %.po
 	mkdir -p $(shell dirname $@)/LC_MESSAGES
@@ -29,14 +30,10 @@ all-mo: $(MOFILES)
 	cat $@
 	! grep -q msgid $@
 
-check: $(POXFILES)
-	msgfmt -c ${POTFILE}
+%.edit.po:
+	touch $@
 
-# Merge PO files
-update-po:
-	for f in $(shell find ./ -name "*.po") ; do \
-		msgmerge -N --backup=none -U $$f ${POTFILE} ; \
-	done
+check: $(POXFILES)
 
 # Unify duplicate translations
 uniq-po:
@@ -44,19 +41,20 @@ uniq-po:
 		msguniq $$f -o $$f ; \
 	done
 
-tx-pull:
+tx-pull: $(EDITFILES)
 	tx pull -f
-	for f in $(POFILES) ; do \
+	for f in $(EDITFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done
-	-git commit -a -m "i18n - pulling from tx"
 
-reset-po:
-	# merging po files is unnecessary when using transifex.com
-	git checkout -- ../locale/*/*po
+tx-update: tx-pull
+	@echo
+	@echo Run rake plugin:gettext[$(DOMAIN)] from the Foreman installation, then make -C locale mo-files to finish
+	@echo
 
-tx-update: tx-pull reset-po $(MOFILES)
-	# amend mo files
-	git add ../locale/*/LC_MESSAGES
-	git commit -a --amend -m "i18n - pulling from tx"
-	-echo Changes commited!
+mo-files: $(MOFILES)
+	git add $(POFILES) $(POTFILE) ../locale/*/LC_MESSAGES
+	git commit -m "i18n - pulling from tx"
+	@echo
+	@echo Changes commited!
+	@echo


### PR DESCRIPTION
Linked with https://github.com/theforeman/foreman/pull/2096.

3.1.13 adds an intermediate .edit.po file alongside each .po, which is meant
to be kept outside of SCM and updated by users, whereupon it's merged back into
the .po on the next rake gettext:find execution.

Previously we overwrote all gettext .po file changes with files directly from
Transifex, but now these are downloaded to .edit.po and gettext merges them
back in.

To update a plugin's translations, this now requires the maintainer to:

1. run `make -C locale tx-update` to pull translations to .edit.po
2. run `rake plugin:gettext[foreman_plugin]` (Foreman) to merge .edit.po to .po
3. run `make -C locale mo-files` to refresh MO binaries from PO files

I've updated the instructions on http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Translating to match.