### PR TITLE
Fix rake test enhance to fail when plugin test errors occur

### DIFF
--- a/lib/tasks/foreman_plugin_template_tasks.rake
+++ b/lib/tasks/foreman_plugin_template_tasks.rake
@@ -36,14 +36,9 @@ namespace :foreman_plugin_template do
   end
 end
 
-Rake::Task[:test].enhance do
-  Rake::Task['test:foreman_plugin_template'].invoke
-end
+Rake::Task[:test].enhance ['test:foreman_plugin_template']
 
 load 'tasks/jenkins.rake'
 if Rake::Task.task_defined?(:'jenkins:unit')
-  Rake::Task['jenkins:unit'].enhance do
-    Rake::Task['test:foreman_plugin_template'].invoke
-    Rake::Task['foreman_plugin_template:rubocop'].invoke
-  end
+  Rake::Task['jenkins:unit'].enhance ['test:foreman_plugin_template', 'foreman_plugin_template:rubocop']
 end


### PR DESCRIPTION
Plugin test tasks are now added as pre-requisites rather than additional
code, so failures cause the whole rake run and subsequent tasks to
abort.

---

Seen at https://github.com/theforeman/foreman_remote_execution/pull/175#issuecomment-213449438, can be reproduced by adding a syntax error into the plugin test helper and running `rake test`.