### PR TITLE
Disable Ruby warnings in test rake task

### DIFF
--- a/lib/tasks/foreman_plugin_template_tasks.rake
+++ b/lib/tasks/foreman_plugin_template_tasks.rake
@@ -16,6 +16,7 @@ namespace :test do
     t.libs << ['test', test_dir]
     t.pattern = "#{test_dir}/**/*_test.rb"
     t.verbose = true
+    t.warning = false
   end
 end
 


### PR DESCRIPTION
Matches core behaviour with Rails when using Rake 11.