### PR TITLE
Fix rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 inherit_from:
   - .rubocop_todo.yml
 
-AllCops:
-  RunRailsCops: true # always run the rails cops
+Rails:
+  Enabled: true
 
 # Don't enforce documentation
 Style/Documentation:


### PR DESCRIPTION
Otherwise we get

    Error: obsolete parameter RunRailsCops (for AllCops) found in
    rubocop.yml
    Use the following configuration instead:
    Rails:
      Enabled: true