### PR TITLE
Remove deface from template

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ This example plugin comes with:
 
 These examples show how to add to Foreman in various ways.
 
+### Further examples
+
+The [How to create a plugin](http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin)
+wiki page contains a lot of information on supported plugin extension points in
+Foreman and how to use them from a plugin.
+
 ### i18n
 
 From your Foreman checkout, run `rake plugin:gettext[foreman_plugin_example]` to

--- a/app/overrides/dashboard/index/sample_override.html.erb.deface
+++ b/app/overrides/dashboard/index/sample_override.html.erb.deface
@@ -1,4 +1,0 @@
-<!-- insert_before 'div:contains("title_action")' -->
-<%= title_actions "<h2>ForemanPluginTemplate</h2>" %>
-
-<!-- vim: set ft=eruby : -->

--- a/foreman_plugin_template.gemspec
+++ b/foreman_plugin_template.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib,locale}/**/*'] + ['LICENSE', 'Rakefile', 'README.md']
   s.test_files = Dir['test/**/*']
 
-  s.add_dependency 'deface'
   s.add_development_dependency 'rubocop'
   s.add_development_dependency 'rdoc'
 end

--- a/lib/foreman_plugin_template/engine.rb
+++ b/lib/foreman_plugin_template/engine.rb
@@ -1,5 +1,3 @@
-require 'deface'
-
 module ForemanPluginTemplate
   class Engine < ::Rails::Engine
     engine_name 'foreman_plugin_template'


### PR DESCRIPTION
It's unnecessary in many plugins, causing new plugins to be created with
a superfluous dependency.

It remains documented at
http://projects.theforeman.org/projects/foreman/wiki/How_to_Create_a_Plugin#Modify-Existing-Foreman-View-using-Deface