### PR TITLE
Remove useless date from gemspec

### DIFF
--- a/foreman_plugin_template.gemspec
+++ b/foreman_plugin_template.gemspec
@@ -1,10 +1,8 @@
 require File.expand_path('../lib/foreman_plugin_template/version', __FILE__)
-require 'date'
 
 Gem::Specification.new do |s|
   s.name        = 'foreman_plugin_template'
   s.version     = ForemanPluginTemplate::VERSION
-  s.date        = Time.zone.today
   s.license     = 'GPL-3.0'
   s.authors     = ['TODO: Your name']
   s.email       = ['TODO: Your email']


### PR DESCRIPTION
This does not work and even does not make sense, since gemspec is being executed, it always resolves to current data and time I believe. Removing.

```
[!] There was an error parsing `Gemfile`: 
[!] There was an error while loading `foreman_discovery.gemspec`: undefined method `zone' for Time:Class. Bundler cannot continue.

 #  from /home/lzap/work/foreman_discovery/foreman_discovery.gemspec:7
 #  -------------------------------------------
 #    s.version = ForemanDiscovery::VERSION
 >    s.date        = Time.zone.today
 #    s.authors = IO.readlines("AUTHORS").map(&:strip)
 #  -------------------------------------------
. Bundler cannot continue.

 #  from /home/lzap/work/foreman_discovery/Gemfile:3
 #  -------------------------------------------
 #  
 >  gemspec
 #  
 #  -------------------------------------------

```