### PR TITLE
Correctly require test libs

### DIFF
--- a/lib/tasks/foreman_plugin_template_tasks.rake
+++ b/lib/tasks/foreman_plugin_template_tasks.rake
@@ -14,8 +14,9 @@ end
 namespace :test do
   desc 'Test ForemanPluginTemplate'
   Rake::TestTask.new(:foreman_plugin_template) do |t|
-    test_dir = File.join(File.dirname(__FILE__), '../..', 'test')
-    t.libs << ['test', test_dir]
+    test_dir = File.expand_path('../../test', __dir__)
+    t.libs << 'test'
+    t.libs << test_dir
     t.pattern = "#{test_dir}/**/*_test.rb"
     t.verbose = true
     t.warning = false


### PR DESCRIPTION
Test libs were not properly required as we were adding an array not a path.
This didn't work reliably. Fixing it to include paths directly.