### PR TITLE
Fix directory for tx pull

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -43,7 +43,7 @@ uniq-po:
 	done
 
 tx-pull: $(EDITFILES)
-	tx pull -f
+	cd .. && tx pull -f
 	for f in $(EDITFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done


### PR DESCRIPTION
From what I've seen, at least with the new tx client, tx pull needs to be invoked from the repository root, not from the locale directory.