### PR TITLE
Add build-mo-files task

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -55,7 +55,9 @@ tx-update: tx-pull
 	@echo then run make -C locale mo-files to finish
 	@echo
 
-mo-files: $(MOFILES)
+build-mo-files: $(MOFILES)
+
+mo-files: build-mo-files
 	git add $(POFILES) $(POTFILE) $(JSFILES) ../locale/*/LC_MESSAGES
 	git commit -m "i18n - pulling from tx"
 	@echo


### PR DESCRIPTION
Splitting it off from the main mo-files task allows calling it in packaging or other steps where there is no git.