### PR TITLE
call `register_gettext` inside Foreman::Plugin.register

### DIFF
--- a/lib/foreman_plugin_template/engine.rb
+++ b/lib/foreman_plugin_template/engine.rb
@@ -2,7 +2,6 @@ module ForemanPluginTemplate
   class Engine < ::Rails::Engine
     isolate_namespace ForemanPluginTemplate
     engine_name 'foreman_plugin_template'
-    register_gettext
 
     config.autoload_paths += Dir["#{config.root}/app/controllers/concerns"]
     config.autoload_paths += Dir["#{config.root}/app/helpers/concerns"]
@@ -19,6 +18,7 @@ module ForemanPluginTemplate
     initializer 'foreman_plugin_template.register_plugin', :before => :finisher_hook do |_app|
       Foreman::Plugin.register :foreman_plugin_template do
         requires_foreman '>= 3.7.0'
+        register_gettext
 
         # Add Global files for extending foreman-core components and routes
         register_global_js_file 'global'


### PR DESCRIPTION
otherwise it fails to find the method