### PR TITLE
Run permissions tests from Foreman core

### DIFF
--- a/lib/tasks/foreman_plugin_template_tasks.rake
+++ b/lib/tasks/foreman_plugin_template_tasks.rake
@@ -13,11 +13,10 @@ end
 # Tests
 namespace :test do
   desc 'Test ForemanPluginTemplate'
-  Rake::TestTask.new(:foreman_plugin_template) do |t|
-    test_dir = File.expand_path('../../test', __dir__)
-    t.libs << 'test'
-    t.libs << test_dir
-    t.pattern = "#{test_dir}/**/*_test.rb"
+  Rake::TestTask.new(:foreman_plugin_template => 'db:test:prepare') do |t|
+    t.libs << ForemanPluginTemplate::Engine.root.join('test')
+    t.pattern = ForemanPluginTemplate::Engine.root.join('test', '**', '*_test.rb')
+    t.test_files = [Rails.root.join('test/unit/foreman/access_permissions_test.rb')]
     t.verbose = true
     t.warning = false
   end


### PR DESCRIPTION
Opened to showcase an alternative to https://github.com/theforeman/actions/pull/16.

The idea is that plugins should always run a certain test from core. This relies on:

> If both pattern and test_files are used, then the list of test files is the union of the two.

It also starts to depend on `db:test:prepare` since I saw that at least in `foreman_tasks`.