### PR TITLE
Revert "Add build-mo-files task"

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -55,9 +55,7 @@ tx-update: tx-pull
 	@echo then run make -C locale mo-files to finish
 	@echo
 
-build-mo-files: $(MOFILES)
-
-mo-files: build-mo-files
+mo-files: $(MOFILES)
 	git add $(POFILES) $(POTFILE) $(JSFILES) ../locale/*/LC_MESSAGES
 	git commit -m "i18n - pulling from tx"
 	@echo


### PR DESCRIPTION
This reverts commit e8b2f0babe3eb13069405a37f7d5a673e31d4da8. This is because there already was the all-mo task which does the same thing.