### PR TITLE
Pull in new languages with 50% or more translated

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -6,3 +6,4 @@ file_filter = locale/<lang>/foreman_plugin_template.edit.po
 source_file = locale/foreman_plugin_template.pot
 source_lang = en
 type = PO
+minimum_perc = 50

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -43,7 +43,7 @@ uniq-po:
 	done
 
 tx-pull: $(EDITFILES)
-	cd .. && tx pull -f
+	cd .. && tx pull -f --all
 	for f in $(EDITFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done


### PR DESCRIPTION
By default tx pull only fetches files that locally exist. Adding --all with a minimum percentage automatically downloads new languages as $lang.edit.po. This is then picked up later in the extraction process.

For clarify: the -f option is because timestamps with git are unreliable and we simply always want to pull everything. These days there is also --use-git-timestamps which may be sufficient.