### PR TITLE
Put locale/action_names.rb into gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ test/dummy/db/*.sqlite3
 test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
+locale/action_names.rb
 locale/*.mo
 locale/*/*.edit.po
 locale/*/*.po.time_stamp


### PR DESCRIPTION
This file gets generated from a rake task in `foreman-tasks` which gets invoked when `gettext:find` gets called. Usually this file gets committed to git, but it has to be done explicitly. This change makes the file get added/removed automatically.