### PR TITLE
Ensure .po.time_stamp files are correct during extraction

### DIFF
--- a/locale/Makefile
+++ b/locale/Makefile
@@ -50,7 +50,10 @@ uniq-po:
 	done
 
 tx-pull: $(EDITFILES)
-	cd .. && tx pull -f --all
+	# Initialize new languages
+	cd .. && tx pull -f --all --minimum-perc 50
+	# Force update all existing languages
+	cd .. && tx pull -f --minimum-perc 0
 	for f in $(EDITFILES) ; do \
 		sed -i 's/^\("Project-Id-Version: \).*$$/\1$(DOMAIN) $(VERSION)\\n"/' $$f; \
 	done

--- a/locale/Makefile
+++ b/locale/Makefile
@@ -31,8 +31,15 @@ all-mo: $(MOFILES)
 	cat $@
 	! grep -q msgid $@
 
-%.edit.po:
+%.edit.po: %.po.time_stamp
 	touch $@
+
+# gettext will trash the .edit.po file if the time stamp doesn't exist or is older than the po file
+%.po.time_stamp: %.po
+	touch --reference $< $@
+
+# Prevent make from treating this as an intermediate file to be cleaned up
+.PRECIOUS: %.po.time_stamp
 
 check: $(POXFILES)
 


### PR DESCRIPTION
The Ruby gettext library wants the `.po.time_stamp` file to be at least as new as the `.po` file. If it doesn't exist or is older, it will remove the `.edit.po` file and then copy the `.po` file to `.edit.po`.

A more concrete example what ends up happening:

```sh
make -C locale tx-pull # updates $domain.edit.po

# This all assumes $domain.po exists
if [ ! -f $domain.po.time_stamp ] -o [ $domain.po -nt $domain.po.time_stamp ] ; then
    rm -f $domain.edit.po
fi
if [ ! -f $domain.edit.po ] ; then
    cp $domain.po $domain.edit.po

    # Merge in the new messages from the template
    msgmerge --update --sort-by-file --no-wrap $domain.edit.po $domain.pot
    if [ -f $domain.po ] -a [ $domain.po -nt $domain.edit.po ] ; then
        msgmerge --output $domain.edit.po --sort-by-file --no-wrap --no-obsolete-entries $domain.po $domain.edit.po
    fi
fi
```

This ensures that `$domain.po.time_stamp` is always the same mtime as `$domain.po` which prevents the gettext library from removing the updated `$domain.edit.po` file.

It means there is no message merging and we rely on Transifex for doing that part for us.