### PR TITLE
Correct instructions in release flow

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,9 +10,9 @@ To release the plugin the following steps are required:
 4. Make a commit "Bump version to $version"
 5. Place a version tag on the commit with `git tag v$version`
    - Ideally the tag should be signed.
-6. Push the commit and the tag to the upstream repository
+6. Push the commit and the tag to the upstream repository with `git push --follow-tags`
 
-When the tag is pushed to git, [the release workflow](.github/workflows/release.yml) should get triggered and should build the gem and push it to [rubygems.org](https://rubygems.org/gems/foreman-tasks).
+When the tag is pushed to git, [the release workflow](.github/workflows/release.yml) should get triggered and should build the gem and push it to [rubygems.org](https://rubygems.org/gems/foreman_plugin_template).
 
 Once the new version lands in rubygems, consider filing a packaging PR on [foreman-packaging](https://github.com/theforeman/foreman-packaging) or triggering it via automation with:
 ```shell
@@ -22,6 +22,7 @@ gh workflow run bump_packages.yml \
 ```
 
 ### Note on permissions
+
 The steps outlined above require write access to the repository. This is generally controlled by membership in the [@foreman_plugin_template](https://github.com/orgs/theforeman/teams/foreman_plugin_template) team. If needed, steps 1-4 can be done even without permissions. In that case, skip step 5, push the changes to your own fork and send us a pull request, asking for a maintainer to perform step 5.
 
 Similar situation applies to the packaging workflow. It can be triggered (and resulting PRs merged) by members of the team. PRs can also be prepared by hand and sent by anyone.


### PR DESCRIPTION
This replaces foreman-tasks with foreman_plugin_template. It also adds a command to push the commit and tag in a single command since many don't know about it. Then it also adds an empty line after the header, making it pass MD022 from markdownlint.

Fixes: 2c2a0e24f54a40b0d769dfcca2352c5cf9006273 ("Implement release process RFC")